### PR TITLE
Add function getUrlParamKey()

### DIFF
--- a/lib/Url/Generator.php
+++ b/lib/Url/Generator.php
@@ -426,6 +426,21 @@ class Generator
         return false;
     }
 
+    /**
+     * Returns the parameter name for rex_getUrl().
+     * @return string Parameter name
+     */
+	public static function getUrlParamKey()
+    {
+        $data = self::getData();
+        if(key_exists('urlParamKey', $data)) {
+        	return $data['urlParamKey'];
+        }
+        else {
+        	return FALSE;
+        }
+    }
+    
     public static function getData()
     {
         self::ensurePaths();

--- a/lib/Url/Generator.php
+++ b/lib/Url/Generator.php
@@ -433,7 +433,7 @@ class Generator
 	public static function getUrlParamKey()
     {
         $data = self::getData();
-        if(key_exists('urlParamKey', $data)) {
+        if($data !== FALSE && key_exists('urlParamKey', $data)) {
         	return $data['urlParamKey'];
         }
         else {


### PR DESCRIPTION
Diese Funktion wird bei mehrfacher Verwendung von URL Parametern z.B. in einem Template eine wichtige Vereinfachung darstellen.