### PR TITLE
Neue Features/Methoden und kleiner Bugfix canonicalUrl

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -20,6 +20,7 @@ url_generate_notice_path_names = ohne <code>/</code> am Anfang und Ende<br />Der
 url_generate_notice_restriction = Hiermit kann das erstellen der Urls für den obigen Artikel eingeschränkt werden. Hilfreich bei Relationen mit einer anderen Tabelle. News können zum Bsp. in mehrere Kategorien aufgeteilt werden.
 url_generate_notice_seo_title = Spalte aus der der Titel erzeugt wird
 url_generate_notice_seo_description = Spalte aus der die Description erzeugt wird
+url_generate_notice_seo_img = Spalte aus der das Bild genommen wird
 url_generate_notice_sitemap_add = Urls in die Sitemap.xml aufnehmen?
 url_generate_notice_sitemap_frequency = Frequenz
 url_generate_notice_sitemap_priority = Wichtigkeit

--- a/lib/Url/Generator.php
+++ b/lib/Url/Generator.php
@@ -79,6 +79,7 @@ class Generator
             $table->pathCategories = $parameters[$databaseAndTable . '_path_categories'];
             $table->seoTitle = $parameters[$databaseAndTable . '_seo_title'];
             $table->seoDescription = $parameters[$databaseAndTable . '_seo_description'];
+            $table->seoImg = $parameters[$databaseAndTable . '_seo_img'];
             $table->sitemapAdd = $parameters[$databaseAndTable . '_sitemap_add'];
             $table->sitemapFrequency = $parameters[$databaseAndTable . '_sitemap_frequency'];
             $table->sitemapPriority = $parameters[$databaseAndTable . '_sitemap_priority'];
@@ -202,6 +203,9 @@ class Generator
                     }
                     if (isset($table->seoDescription) && $table->seoDescription != '') {
                         $querySelect[] = $table->name . '.' . $table->seoDescription . ' AS seo_description';
+                    }
+                    if (isset($table->seoImg) && $table->seoImg != '') {
+                        $querySelect[] = $table->name . '.' . $table->seoImg . ' AS seo_img';
                     }
 
                     $queryFrom = '';
@@ -356,6 +360,12 @@ class Generator
                                 $object->seoDescription = $entry['seo_description'];
                             } else {
                                 $object->seoDescription = '';
+                            }
+
+                            if (isset($entry['seo_img'])) {
+                                $object->seoImg = $entry['seo_img'];
+                            } else {
+                                $object->seoImg = '';
                             }
 
                             $urlParamKey = (trim($table->urlParamKey) == '') ? self::$pathsNoUrlParamKey : $table->urlParamKey;

--- a/lib/Url/Rewriter/Rewriter.php
+++ b/lib/Url/Rewriter/Rewriter.php
@@ -71,6 +71,11 @@ abstract class Rewriter
     /**
      * @return string
      */
+    abstract function getFullPath($path);
+
+    /**
+     * @return string
+     */
     abstract function getSuffix();
 
     /**

--- a/lib/Url/Rewriter/Yrewrite.php
+++ b/lib/Url/Rewriter/Yrewrite.php
@@ -109,6 +109,14 @@ class Yrewrite extends Rewriter
     /**
      * @return string
      */
+    public function getFullPath($path)
+    {
+        return \rex_yrewrite::getFullPath($path);
+    }
+
+    /**
+     * @return string
+     */
     public function getSuffix()
     {
         $scheme = \rex_yrewrite::getScheme();

--- a/lib/Url/Seo.php
+++ b/lib/Url/Seo.php
@@ -32,17 +32,32 @@ class Seo
 
     public function getTitleTag()
     {
-        return $this->isUrl() ? '<title>' . htmlspecialchars($this->normalize($this->data->seoTitle)) . '</title>' : $this->rewriterSeo->{$this->rewriter->getSeoTitleTagMethod()}();
+        return $this->isUrl() ? '<title>' . htmlspecialchars($this->getTitle()) . '</title>' : $this->rewriterSeo->{$this->rewriter->getSeoTitleTagMethod()}();
+    }
+
+    public function getTitle()
+    {
+        return $this->normalize($this->data->seoTitle);
     }
 
     public function getDescriptionTag()
     {
-        return $this->isUrl() ? '<meta name="description" content="'.htmlspecialchars($this->normalize($this->data->seoDescription)).'" />' : $this->rewriterSeo->{$this->rewriter->getSeoDescriptionTagMethod()}();
+        return $this->isUrl() ? '<meta name="description" content="' . htmlspecialchars($this->getDescription()) . '" />' : $this->rewriterSeo->{$this->rewriter->getSeoDescriptionTagMethod()}();
     }
 
-    public function getCanonicalTag()
+    public function getDescription()
     {
-        return $this->isUrl() ? '<link rel="canonical" href="' . $this->data->url . '" />' : $this->rewriterSeo->{$this->rewriter->getSeoCanonicalTagMethod()}();
+        return $this->normalize($this->data->seoDescription);
+    }
+
+    public function getCanonicalUrlTag()
+    {
+        return $this->isUrl() ? '<link rel="canonical" href="' . $this->getCanonicalUrl() . '" />' : $this->rewriterSeo->{$this->rewriter->getSeoCanonicalTagMethod()}();
+    }
+
+    public function getCanonicalUrl()
+    {
+        return $this->rewriter->getFullPath(ltrim($this->data->url, "/"));
     }
 
     public function getHreflangTags()
@@ -72,6 +87,11 @@ class Seo
     public function getRobotsTag()
     {
         return $this->rewriterSeo->{$this->rewriter->getSeoRobotsTagMethod()}();
+    }
+
+    public function getImg()
+    {print_r($this->data);
+        return $this->data->img;
     }
 
     protected function isUrl()

--- a/pages/generate.php
+++ b/pages/generate.php
@@ -424,11 +424,24 @@ if ($func == '') {
             $name = $table . '_seo_description';
             $f = $fieldContainer->addGroupedField($group, $type, $name);
             $f->setHeader('<div class="url-grid-item">');
-            $f->setFooter('</div></div>');
+            $f->setFooter('</div>');
             $f->setPrefix('<div class="rex-select-style">');
             $f->setSuffix('</div>');
             $f->setAttribute('disabled', 'true');
             $f->setNotice($this->i18n('url_generate_notice_seo_description'));
+            $select = $f->getSelect();
+            $select->addOption($this->i18n('url_generate_no_selection'), '');
+            $select->addOptions($options, true);
+
+            $type = 'select';
+            $name = $table . '_seo_img';
+            $f = $fieldContainer->addGroupedField($group, $type, $name);
+            $f->setHeader('<div class="url-grid-item">');
+            $f->setFooter('</div></div>');
+            $f->setPrefix('<div class="rex-select-style">');
+            $f->setSuffix('</div>');
+            $f->setAttribute('disabled', 'true');
+            $f->setNotice($this->i18n('url_generate_notice_seo_img'));
             $select = $f->getSelect();
             $select->addOption($this->i18n('url_generate_no_selection'), '');
             $select->addOptions($options, true);


### PR DESCRIPTION
Neu kann man im Backend (im SEO Teil) angeben, ob es eine SEO-Bild-Spalte gibt und wenn ja, wie die Spalte heisst. Das ist zum Beispiel nützlich um open graph tags zu füttern oder ähnliches.

Ausserdem habe ich ein paar neue Methoden implementiert, um direkt auf Values (ohne Tags) zuzugreifen, ähnlich wie bei yrewrite.

Zu guter Letzt hab ich noch einen Bug gefixt bei den Canonical URLs, die wurden bei mir relativ ausgegeben, sollten aber absolut sein.