### PR TITLE
Fix #47

### DIFF
--- a/lib/Url/Generator.php
+++ b/lib/Url/Generator.php
@@ -617,7 +617,6 @@ class Generator
                 if ((int) $value > 0) {
                     $articleIdFound = self::getArticleIdByUrlParamKey($key);
                     if ($articleIdFound) {
-                        $articleId = $articleIdFound;
                         $primaryId = (int) $value;
                         $urlParamKey = $key;
                         unset($params['params'][$key]);


### PR DESCRIPTION
Warum wird die Artikel ID überschrieben? Unnötig und verursacht Fehler wenn bei mehreren Artikeln der selbe key verwendet wird!