### PR TITLE
Fix #51

### DIFF
--- a/lib/Url/Generator.php
+++ b/lib/Url/Generator.php
@@ -275,7 +275,10 @@ class Generator
                             if (count(\rex_clang::getAll()) >= 2 && $clangId == '0' && $table->clang_id != '') {
                                 $articleClangId = $entry['clang_id'];
                             }
-                            $articleUrl = Url::getRewriter()->getFullUrl($articleId, $articleClangId);
+                            else if(count(\rex_clang::getAll()) == 1 && $clangId == '0') {
+                            	$articleClangId = \rex_clang::getStartId();
+                            }
+                           $articleUrl = Url::getRewriter()->getFullUrl($articleId, $articleClangId);
                             $articleUrl = self::stripRewriterSuffix($articleUrl) . '/';
                             $url = Url::parse($articleUrl);
 


### PR DESCRIPTION
Falls $clangId = 0 und nur eine Sprache in Redaxo existiert wird diese Sprache als Fallback gesetzt, da sonst in der pathlist bei den Einträgen die clangId 0 gespeichert wird.