### PR TITLE
urldecode eingefügt #67

### DIFF
--- a/lib/Url/Generator.php
+++ b/lib/Url/Generator.php
@@ -400,10 +400,10 @@ class Generator
                     foreach ($urlParamKeys as $urlParamKey => $ids) {
                         foreach ($ids as $id => $clangIds) {
                             foreach ($clangIds as $clangId => $object) {
-                                if ($currentUrl->getPath() == $object['url'] || in_array($currentUrl->getPath(), $object['pathNames'])) {
+                                if (urldecode($currentUrl->getPath()) == $object['url'] || in_array(urldecode($currentUrl->getPath()), $object['pathNames'])) {
                                     return ['article_id' => $articleId, 'clang' => $clangId];
                                 }
-                                if (false !== $categoryId = array_search($currentUrl->getPath(), $object['pathCategories'])) {
+                                if (false !== $categoryId = array_search(urldecode($currentUrl->getPath()), $object['pathCategories'])) {
                                     return ['article_id' => $categoryId, 'clang' => $clangId];
                                 }
                             }
@@ -451,7 +451,7 @@ class Generator
                     foreach ($urlParamKeys as $urlParamKey => $ids) {
                         foreach ($ids as $id => $clangIds) {
                             foreach ($clangIds as $clangId => $object) {
-                                if ($currentUrl->getPath() == $object['url'] || in_array($currentUrl->getPath(), $object['pathNames']) || in_array($currentUrl->getPath(), $object['pathCategories'])) {
+                                if (urldecode($currentUrl->getPath()) == $object['url'] || in_array(urldecode($currentUrl->getPath()), $object['pathNames']) || in_array(urldecode($currentUrl->getPath()), $object['pathCategories'])) {
                                     return $id;
                                 }
                             }
@@ -474,7 +474,7 @@ class Generator
                     foreach ($urlParamKeys as $urlParamKey => $ids) {
                         foreach ($ids as $id => $clangIds) {
                             foreach ($clangIds as $clangId => $object) {
-                                if ($currentUrl->getPath() == $object['url'] || in_array($currentUrl->getPath(), $object['pathNames']) || in_array($currentUrl->getPath(), $object['pathCategories'])) {
+                                if (urldecode($currentUrl->getPath()) == $object['url'] || in_array(urldecode($currentUrl->getPath()), $object['pathNames']) || in_array(urldecode($currentUrl->getPath()), $object['pathCategories'])) {
                                     return (object) $object;
                                 }
                             }
@@ -498,7 +498,7 @@ class Generator
                         foreach ($ids as $id => $clangIds) {
                             foreach ($clangIds as $clangId => $object) {
                                 foreach ($object['pathNames'] as $pathName) {
-                                    if ($currentUrl->getPath() == $pathName) {
+                                    if (urldecode($currentUrl->getPath()) == $pathName) {
                                         return self::stripRewriterSuffix(str_replace($object['url'], '', $pathName));
                                     }
                                 }


### PR DESCRIPTION
Wenn überhaupt Chinesischer oder Russische Schriftzeichen gespeichert werden, sind sie in `$object['pathNames']`, `$object['url']` und `$object['pathCategories']` mit `urlencode()` codiert (siehe hier https://github.com/yakamara/redaxo_yrewrite/blob/67cedaa881a2f54601e534a75464003680723488/lib/scheme.php#L135). Die Generator Klasse wird mit der Änderung dem gerecht und kann erst dann in den geänderten Zeilen einen korrekten Vergleich starten.