### PR TITLE
SEO-Image - erstes Element einer rex_medialist / be_media

### DIFF
--- a/lib/Url/UrlManager.php
+++ b/lib/Url/UrlManager.php
@@ -158,7 +158,7 @@ class UrlManager
      */
     public function getSeoImage()
     {
-        return $this->getSeoValue('image');
+        return array_shift(explode(",",$this->getSeoValue('image')));
     }
 
     /**


### PR DESCRIPTION
Sodass man bei einem Feld mit mehreren Dateien automatisch die erste Datei der kommaseparierten Liste nutzen kann.

closes #109