### PR TITLE
Übersetzung korrigiert

### DIFF
--- a/pages/generator.profiles.php
+++ b/pages/generator.profiles.php
@@ -661,7 +661,7 @@ if ($func == '') {
         $f->setPrefix('<div class="rex-select-style">');
         $f->setSuffix('</div>');
         $fieldRelationTableSelect = $f->getSelect();
-        $fieldRelationTableSelect->addOption($this->i18n('url_no_table_selected'), '');
+        $fieldRelationTableSelect->addOption($this->i18n('url_generator_table_not_selected'), '');
 
         $activeRelationTable = $f->getValue();
 


### PR DESCRIPTION
Die Übersetzung hatte nicht gestimmt.