### PR TITLE
Doku Verbesserung für verkürzte URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ Der Extension Point URL_MANAGER_PRE_SAVE gibt die Möglichkeit eine URL vor dem 
 
 ```php
 <?php
-if(\rex::isBackend()) {
-	rex_extension::register('URL_MANAGER_PRE_SAVE', 'rex_url_shortener');
-}
+rex_extension::register('URL_MANAGER_PRE_SAVE', 'rex_url_shortener');
 
 /**
  * Kürzt URL für ALLE Profile indem es die Artikel und Kategorienamen aus der URL entfernt.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ function rex_url_shortener(rex_extension_point $ep) {
 	// URL muss nur gekürzt werden, wenn es sich nicht im den Startartikel der Domain handelt
 	if($article_id != rex_yrewrite::getDomainByArticleId($article_id, $clang_id)->getStartId()) {
 		$article_url = rex_getUrl($article_id, $clang_id);
-		$start_article_url = rex_getUrl(rex_article::getSiteStartArticleId(), $clang_id);
+		$start_article_url = rex_getUrl(rex_yrewrite::getDomainByArticleId($article_id, $clang_id)->getStartId(), $clang_id);
 		$article_url_without_lang_slug = '';
 		if(strlen($start_article_url) == 1) {
             // Wenn lang slug  im Startartikel nicht angezeigt wird


### PR DESCRIPTION
Nach dem Löschen des Caches kann der Aufruf zur Generierung der URLs auch aus dem Frontend ausgelöst werden. Daher muss der Extension Point auch im Frontend aufgerufen werden.