### PR TITLE
Weiterer Unique Index hinzugefügt

### DIFF
--- a/install.php
+++ b/install.php
@@ -51,4 +51,5 @@
     ->ensureColumn(new \rex_sql_column('updateuser', 'VARCHAR(255)'))
 
     ->ensureIndex(new \rex_sql_index('url', ['url'], \rex_sql_index::UNIQUE))
+    ->ensureIndex(new \rex_sql_index('unique_dataset', ['profile_id', 'article_id', 'clang_id', 'data_id'], \rex_sql_index::UNIQUE))
     ->ensure();


### PR DESCRIPTION
Profil ID, Artikel ID, Clang ID und Datensatz ID müssen in Kombination einzigartig sein. Wird der Extension Point URL_MANAGER_PRE_SAVE nicht korrekt benutzt, können mehrer Einträge in der URL Tabelle entstehen. Beispiel aus einem DB Export:
INSERT INTO `rex_url_generator_url` (`profile_id`, `article_id`, `clang_id`, `data_id`, `url`) VALUES
(18, 1, 1, 216, '//www.mydomain.com/en/plate-cutting-and-drilling-centre/kf-2607-e/'),
(18, 1, 1, 216, '//www.mydomain.com/en/products/machines/plate-cutting-and-drilling-centre/kf-2607-e/');

Der PR sichert diesen doppelten Eintrag in letzter Instanz ab.
