### PR TITLE
Sprachspezifische Normalisierung erlauben

### DIFF
--- a/lib/Url/Profile.php
+++ b/lib/Url/Profile.php
@@ -274,10 +274,10 @@ class Profile
         for ($index = 1; $index <= self::SEGMENT_PART_COUNT; ++$index) {
             if ($dataset->hasValue(self::ALIAS.'_segment_part_'.$index)) {
                 $concatSegmentParts .= $this->getSegmentPartSeparators()[$index] ?? '';
-                $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue(self::ALIAS.'_segment_part_'.$index), $dataset->getValue(self::ALIAS.'_clang_id'));
+                $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue(self::ALIAS.'_segment_part_'.$index), $clangId);
             }
         }
-        $dataPath->appendPathSegments(explode('/', $concatSegmentParts));
+        $dataPath->appendPathSegments(explode('/', $concatSegmentParts), $clangId);
 
         if ($this->hasRelations()) {
             $append = [];
@@ -287,7 +287,7 @@ class Profile
                 for ($index = 1; $index <= self::SEGMENT_PART_COUNT; ++$index) {
                     if ($dataset->hasValue($relation->getAlias().'_segment_part_'.$index)) {
                         $concatSegmentParts .= $this->getSegmentPartSeparators()[$index] ?? '';
-                        $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue($relation->getAlias().'_segment_part_'.$index), $dataset->getValue(self::ALIAS.'_clang_id'));
+                        $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue($relation->getAlias().'_segment_part_'.$index), $clangId);
                     }
                 }
                 if ($relation->getSegmentPosition() === 'BEFORE') {
@@ -298,13 +298,13 @@ class Profile
             }
 
             if ($prepend) {
-                $dataPath->prependPathSegments($prepend);
+                $dataPath->prependPathSegments($prepend, $clangId);
             }
             if ($append) {
-                $dataPath->appendPathSegments($append);
+                $dataPath->appendPathSegments($append, $clangId);
             }
         }
-        $url->appendPathSegments($dataPath->getSegments());
+        $url->appendPathSegments($dataPath->getSegments(), $clangId);
 
         $urlObjects = [];
         $urlObjects[] = [
@@ -326,7 +326,7 @@ class Profile
                 if (count($categories)) {
                     foreach ($categories as $category) {
                         $urlCategory = clone $url;
-                        $urlCategory->appendPathSegments([$category->getName()]);
+                        $urlCategory->appendPathSegments([$category->getName()], $clangId);
                         $urlObjects[] = [
                             'article_id' => $category->getId(),
                             'object' => $urlCategory,
@@ -345,7 +345,7 @@ class Profile
                 $userPathParts = explode('=', $userPathLine);
 
                 $urlUserPath = clone $url;
-                $urlUserPath->appendPathSegments(explode('/', trim($userPathParts[0])));
+                $urlUserPath->appendPathSegments(explode('/', trim($userPathParts[0])), $clangId);
                 $urlObjects[] = [
                     'article_id' => $articleId,
                     'object' => $urlUserPath,

--- a/lib/Url/Profile.php
+++ b/lib/Url/Profile.php
@@ -274,7 +274,7 @@ class Profile
         for ($index = 1; $index <= self::SEGMENT_PART_COUNT; ++$index) {
             if ($dataset->hasValue(self::ALIAS.'_segment_part_'.$index)) {
                 $concatSegmentParts .= $this->getSegmentPartSeparators()[$index] ?? '';
-                $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue(self::ALIAS.'_segment_part_'.$index));
+                $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue(self::ALIAS.'_segment_part_'.$index), $dataset->getValue(self::ALIAS.'_clang_id'));
             }
         }
         $dataPath->appendPathSegments(explode('/', $concatSegmentParts));
@@ -287,7 +287,7 @@ class Profile
                 for ($index = 1; $index <= self::SEGMENT_PART_COUNT; ++$index) {
                     if ($dataset->hasValue($relation->getAlias().'_segment_part_'.$index)) {
                         $concatSegmentParts .= $this->getSegmentPartSeparators()[$index] ?? '';
-                        $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue($relation->getAlias().'_segment_part_'.$index));
+                        $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue($relation->getAlias().'_segment_part_'.$index), $dataset->getValue(self::ALIAS.'_clang_id'));
                     }
                 }
                 if ($relation->getSegmentPosition() === 'BEFORE') {

--- a/lib/Url/Url.php
+++ b/lib/Url/Url.php
@@ -57,15 +57,15 @@ class Url
         $this->removeRewriterSuffix();
     }
 
-    public function appendPathSegments(array $segments)
+    public function appendPathSegments(array $segments, $clangId = 0)
     {
-        $segments = $this->normalize($segments);
+        $segments = $this->normalize($segments, $clangId);
         return $this->modifyPathSegments($this->uri->getPathSegments(), $segments);
     }
 
-    public function prependPathSegments(array $segments)
+    public function prependPathSegments(array $segments, $clangId = 0)
     {
-        $segments = $this->normalize($segments);
+        $segments = $this->normalize($segments, $clangId);
         return $this->modifyPathSegments($segments, $this->uri->getPathSegments());
     }
 
@@ -254,14 +254,14 @@ class Url
         return $this;
     }
 
-    private function normalize($sick)
+    private function normalize($sick, $clangId = 0)
     {
         if (is_string($sick)) {
             $sick = [$sick];
         }
 
         foreach ($sick as $index => $value) {
-            $sick[$index] = self::$rewriter->normalize($value);
+            $sick[$index] = self::$rewriter->normalize($value, $clangId);
         }
         return $sick;
     }

--- a/lib/Url/UrlManager.php
+++ b/lib/Url/UrlManager.php
@@ -360,7 +360,7 @@ class UrlManager
 
                         $expandedOriginUrl = $urlRecord->getUrl();
                         $expandedOriginUrl->handleRewriterSuffix();
-                        $expandedOriginUrl->appendPathSegments($restStructurePathUrl->getSegments());
+                        $expandedOriginUrl->appendPathSegments($restStructurePathUrl->getSegments(), $article->getClangId());
 
                         $urlRecord = self::resolveUrl($expandedOriginUrl);
                     }


### PR DESCRIPTION
Das im D2U Helper zur Verfügung gestellte YRewrite Schema erlaubt für jede Sprache die Möglichkeit zwischen Standard Normalisierung und URL Encodierter Normalisierung zu Unterscheiden. YRewrite übergibt sauber die Sprach ID und so kann in der Normalisierungsmethode die sprachspezifische Normalisierung vorgenommen werden.

Im URL Addon hat das bislang gefehlt. Dieser Pull Request zieht die Sprach ID komplett bis zur Normalisierungsmethode des YRewrite Schemas durch. Um Rückwärtskompatibel zu bleiben wurde der jeweils zusätzliche Parameter optional gemacht.

Der Patch ist bei mir Live. Hier ein Beispiellink: https://www.kaltenbach.com/ru/%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B-%D0%BC%D0%B0%D1%80%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B8/%D1%81%D1%82%D1%80%D1%83%D0%B8%D0%BD%D1%8B%D0%B8-%D0%BF%D1%80%D0%B8%D0%BD%D1%82%D0%B5%D1%80-ink-jet/