### PR TITLE
URL Kodierte URLs sauber anzeigen und verlinken

### DIFF
--- a/pages/generator.urls.php
+++ b/pages/generator.urls.php
@@ -65,7 +65,7 @@ if ($func == '') {
         $url = Url::get($value);
         $url->withSolvedScheme();
 
-        return sprintf('<a href="%s" target="_blank">%s</a>', $url, $value);
+        return sprintf('<a href="%s" target="_blank">%s</a>', urldecode($url), urldecode($value));
     });
 
     $content = $list->get();


### PR DESCRIPTION
Falls URLs mit urlencode() generiert wurden werden sie damit sauber angezeigt und verlinkt.