### PR TITLE
Löschen von Artikeln ausblenden

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -54,6 +54,10 @@ rex_extension::register('PACKAGES_INCLUDED', function (\rex_extension_point $epP
                 if (preg_match($regexp, $subject, $matches)) {
                     $subject = str_replace($matches[0], '<span class="text-muted">'.$matches[1].'</span>', $subject);
                 }
+                $regexp = '@<a href="index\.php\?page=structure.*?article_id='.$id.'&.*?rex-api-call=article_delete.*?>(.*?)<\/a>@';
+                if (preg_match($regexp, $subject, $matches)) {
+                    $subject = str_replace($matches[0], '<span class="text-muted">'.$matches[1].'</span>', $subject);
+                }
             }
             return $subject;
         });


### PR DESCRIPTION
Bisher wird das "Löschen" Feld von Kategorien ausgegraut, wenn die Kategorie in Profilen des Addons verwendet werden. Aber wenn es sich im einen Artikel in der Kategorie handelt, wird das "Löschen" Feld nach wie vor angezeigt. Dieser Fix behebt das. Der Umstand wird in diesem Issue erwähnt: https://github.com/tbaddade/redaxo_url/issues/165.

Vielleicht lässt sich der Code auch in die Zeilen darüber intergrieren. Nur kenne ich mich mit regulären Ausdrücken nicht gut genug aus.