### PR TITLE
Relationsseparator von Relation nehmen

### DIFF
--- a/lib/Url/Profile.php
+++ b/lib/Url/Profile.php
@@ -295,7 +295,7 @@ class Profile
                 $concatSegmentParts = '';
                 for ($index = 1; $index <= self::SEGMENT_PART_COUNT; ++$index) {
                     if ($dataset->hasValue($relation->getAlias().'_segment_part_'.$index)) {
-                        $concatSegmentParts .= $this->getSegmentPartSeparators()[$index] ?? '';
+                        $concatSegmentParts .= $relation->getSegmentPartSeparators()[$index] ?? '';
                         $concatSegmentParts .= Url::getRewriter()->normalize($dataset->getValue($relation->getAlias().'_segment_part_'.$index), $clangId);
                     }
                 }

--- a/lib/Url/ProfileRelation.php
+++ b/lib/Url/ProfileRelation.php
@@ -56,6 +56,15 @@ class ProfileRelation
         return $this->index;
     }
 
+    /**
+     * Get segment part seperators as array
+     * @return array
+     */
+    public function getSegmentPartSeparators()
+    {
+        return $this->segment_part_separators;
+    }
+
     public function getSegmentPosition()
     {
         return $this->position;


### PR DESCRIPTION
Nutzt ein Profil eine Relation und unterscheidet sich der Separator der Relation von dem des Profils, wird bisher der Separator des Profils verwendet. Der in der Relation eingestellte Separator wird ignoriert. Der Patch behebt diesen Fehler und verwendet bei einer Relation auch den in der Relation eingestellten Separator.