### PR TITLE
bump to dev version

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: url
-version: '2.0.0-beta3'
+version: '2.0.0-dev'
 author: Thomas Blum
 supportpage: www.redaxo.org/de/forum/
 


### PR DESCRIPTION
Zur besseren Unterscheidung des Master-Branches zur beta3. Im Slack wird den Leuten immer wieder geraten, mit dem aktuellen Repo-Stand zu arbeiten, weil dort bereits einige Bugfixes enthalten sind.