### PR TITLE
Vorschlag Versionsschema -dev

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: url
-version: '2.0.0-dev'
+version: '2.0.0-dev-2021-12-28'
 author: Thomas Blum
 supportpage: www.redaxo.org/de/forum/
 


### PR DESCRIPTION
Für mich ist nicht mehr nachvollziehbar in meinen Installationen, welcher Stand der 2.0.0-dev installiert ist. Heute z.B. bin ich erst sehr spät darauf gekommen, dass ein Bug in einer vergangenen 2.0.0-dev längst gefixt wurde.

Können wir hier bitte einen Kompromiss eingehen und eine Versionierung für die -dev-Version einführen, wenn schon kein Release erfolgen kann?