### PR TITLE
Make it work with yrewrite_scheme's suffix

### DIFF
--- a/lib/Url/UrlManager.php
+++ b/lib/Url/UrlManager.php
@@ -275,6 +275,7 @@ class UrlManager
             }
 
             $articlePath = $profile->getArticleUrl()->getPath();
+            $articlePath = substr( $articlePath, 0 , strlen($articlePath)-strlen(Url::getRewriter()->getSuffix()));
             if ($articlePath == substr($url->getPath(), 0, strlen($articlePath))) {
                 $resolve = true;
                 break;


### PR DESCRIPTION
 fixes #235 und #196

Der Test, ob die URL teil des Pfades ist, prüfte bisher (mit z.B. ".html") dann ob
"/artikel.html"
der Anfang von 
"/artikel/pfad-aus-dem-URL-AddOn.html"
ist.