### PR TITLE
Update kit-urlparser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,7 @@
 {
     "require": {
-        "riimu/kit-urlparser": "dev-patch-1"
+        "riimu/kit-urlparser": "^2.2.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/gharlan/Kit-UrlParser"
-        }
-    ],
     "scripts": {
         "post-install-cmd": [
             "rm -rf vendor/composer && rm -f vendor/autoload.php"

--- a/vendor/riimu/kit-urlparser/CHANGES.md
+++ b/vendor/riimu/kit-urlparser/CHANGES.md
@@ -1,10 +1,15 @@
 # Changelog #
 
-## Unreleased
+## v2.2.0 (2022-12-13) ##
 
+  * Add support for PHP 8.2
+  * Fix passing nulls to string functions
+  * Deprecated `UriParser::MODE_IDNA2003`
+    * Added `UriParser::MODE_IDNA`, which should be used instead
+    * Internally, the parser will now use UTS46 mode whenever it is available
   * Minor bundled autoloader improvements
-  * Minor improvements to the build process
   * Address minor code quality issues in tests
+  * Update CI to use Github Actions
 
 ## v2.1.0 (2017-06-30) ##
 

--- a/vendor/riimu/kit-urlparser/LICENSE
+++ b/vendor/riimu/kit-urlparser/LICENSE
@@ -1,18 +1,21 @@
-Copyright (c) 2013-2017 Riikka Kalliomäki
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+Copyright (c) 2013-2022 Riikka Kalliomäki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/riimu/kit-urlparser/README.md
+++ b/vendor/riimu/kit-urlparser/README.md
@@ -26,9 +26,9 @@ and IDN ascii formats.
 
 The API documentation is available at: http://kit.riimu.net/api/urlparser/
 
-[![Travis](https://img.shields.io/travis/Riimu/Kit-UrlParser.svg?style=flat-square)](https://travis-ci.org/Riimu/Kit-UrlParser)
-[![Scrutinizer](https://img.shields.io/scrutinizer/g/Riimu/Kit-UrlParser.svg?style=flat-square)](https://scrutinizer-ci.com/g/Riimu/Kit-UrlParser/)
-[![Scrutinizer Coverage](https://img.shields.io/scrutinizer/coverage/g/Riimu/Kit-UrlParser.svg?style=flat-square)](https://scrutinizer-ci.com/g/Riimu/Kit-UrlParser/)
+[![CI](https://img.shields.io/github/workflow/status/Riimu/Kit-UrlParser/CI/main?style=flat-square)](https://github.com/Riimu/Kit-UrlParser/actions)
+[![Scrutinizer](https://img.shields.io/scrutinizer/quality/g/Riimu/Kit-UrlParser/main?style=flat-square)](https://scrutinizer-ci.com/g/Riimu/Kit-UrlParser/)
+[![codecov](https://img.shields.io/codecov/c/github/Riimu/Kit-UrlParser/main?style=flat-square)](https://codecov.io/gh/Riimu/Kit-UrlParser)
 [![Packagist](https://img.shields.io/packagist/v/riimu/kit-urlparser.svg?style=flat-square)](https://packagist.org/packages/riimu/kit-urlparser)
 
 ## Requirements ##
@@ -329,7 +329,7 @@ echo $uri->getPath(); // Outputs: /f%C3%B6%C3%B6/b%C3%A4r.html
 
 UTF-8 characters in the domain name, however, are a bit more complex issue. The
 parser, however, does provide a rudimentary support for parsing these domain
-names using the IDNA2003 mode. For example:
+names using the IDNA mode. For example:
 
 ```php
 <?php
@@ -337,7 +337,7 @@ names using the IDNA2003 mode. For example:
 require 'vendor/autoload.php';
 
 $parser = new \Riimu\Kit\UrlParser\UriParser();
-$parser->setMode(\Riimu\Kit\UrlParser\UriParser::MODE_IDNA2003);
+$parser->setMode(\Riimu\Kit\UrlParser\UriParser::MODE_IDNA);
 
 $uri = $parser->parse('http://www.fööbär.com');
 echo $uri->getHost(); // Outputs: www.xn--fbr-rla2ga.com
@@ -376,6 +376,6 @@ may encounter are as follows:
 
 ## Credits ##
 
-This library is Copyright (c) 2013-2017 Riikka Kalliomäki.
+This library is Copyright (c) 2013-2022 Riikka Kalliomäki.
 
 See LICENSE for license and copying information.

--- a/vendor/riimu/kit-urlparser/composer.json
+++ b/vendor/riimu/kit-urlparser/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "riimu/kit-urlparser",
-  "type": "library",
   "description": "RFC 3986 compliant url parsing library with PSR-7 Uri component",
-  "homepage": "http://kit.riimu.net",
+  "license": "MIT",
+  "type": "library",
   "keywords": [
     "url",
     "uri",
@@ -10,7 +10,6 @@
     "psr-7",
     "rfc3986"
   ],
-  "license": "MIT",
   "authors": [
     {
       "name": "Riikka Kalliomäki",
@@ -18,14 +17,10 @@
       "homepage": "http://riimu.net"
     }
   ],
+  "homepage": "http://kit.riimu.net",
   "require": {
     "php": ">=5.6.0",
     "psr/http-message": "^1.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5.7 || ^6.2",
-    "squizlabs/php_codesniffer": "^3.0",
-    "friendsofphp/php-cs-fixer": "^2.3"
   },
   "suggest": {
     "ext-intl": "Required to parse URIs with IDNs"
@@ -39,5 +34,16 @@
     "psr-4": {
       "Riimu\\Kit\\UrlParser\\": "tests/tests/"
     }
+  },
+  "scripts": {
+    "ci-all": [
+      "@test --do-not-cache-result",
+      "@phpcs --no-cache",
+      "@php-cs-fixer --dry-run --diff --using-cache=no",
+      "@composer normalize --dry-run"
+    ],
+    "php-cs-fixer": "php-cs-fixer fix -v",
+    "phpcs": "phpcs -p",
+    "test": "phpunit"
   }
 }

--- a/vendor/riimu/kit-urlparser/composer.lock
+++ b/vendor/riimu/kit-urlparser/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "205322b7a9857f8371447cfe9cab47cf",
+    "content-hash": "7d6b01a20c9b001307d4dd237ca61f36",
     "packages": [
         {
             "name": "psr/http-message",
@@ -58,59 +58,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/master"
             },
             "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
-            "name": "riimu/kit-urlparser",
-            "version": "v2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Riimu/Kit-UrlParser.git",
-                "reference": "483d9807582b2f524564bcbe58017d985e1907e0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Riimu/Kit-UrlParser/zipball/483d9807582b2f524564bcbe58017d985e1907e0",
-                "reference": "483d9807582b2f524564bcbe58017d985e1907e0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0",
-                "psr/http-message": "^1.0"
-            },
-            "suggest": {
-                "ext-intl": "Required to parse URIs with IDNs"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Riimu\\Kit\\UrlParser\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Riikka Kalliomäki",
-                    "email": "riikka.kalliomaki@gmail.com",
-                    "homepage": "http://riimu.net"
-                }
-            ],
-            "description": "RFC 3986 compliant url parsing library with PSR-7 Uri component",
-            "homepage": "http://kit.riimu.net",
-            "keywords": [
-                "parser",
-                "psr-7",
-                "rfc3986",
-                "uri",
-                "url"
-            ],
-            "support": {
-                "issues": "https://github.com/Riimu/Kit-UrlParser/issues",
-                "source": "https://github.com/Riimu/Kit-UrlParser/tree/v2.2.0"
-            },
-            "time": "2022-12-13T18:51:30+00:00"
         }
     ],
     "packages-dev": [],
@@ -119,7 +66,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.6.0"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }

--- a/vendor/riimu/kit-urlparser/src/ExtendedUriTrait.php
+++ b/vendor/riimu/kit-urlparser/src/ExtendedUriTrait.php
@@ -17,8 +17,8 @@ trait ExtendedUriTrait
 {
     /** @var array<string,int> List of known ports for different schemes */
     private static $standardPorts = [
-        'ftp'   => 21,
-        'http'  => 80,
+        'ftp' => 21,
+        'http' => 80,
         'https' => 443,
     ];
 
@@ -157,7 +157,7 @@ trait ExtendedUriTrait
     {
         $segments = $this->getPathSegments();
         $filename = array_pop($segments);
-        $extension = strrchr($filename, '.');
+        $extension = strrchr((string) $filename, '.');
 
         if ($extension === false) {
             return '';

--- a/vendor/riimu/kit-urlparser/src/Uri.php
+++ b/vendor/riimu/kit-urlparser/src/Uri.php
@@ -95,7 +95,7 @@ class Uri implements UriInterface
     {
         return $this->constructString([
             '%s%s@' => $this->getUserInfo(),
-            '%s%s'  => $this->getHost(),
+            '%s%s' => $this->getHost(),
             '%s:%s' => $this->getPort(),
         ]);
     }
@@ -224,8 +224,8 @@ class Uri implements UriInterface
 
         if (strlen($username) > 0) {
             return $this->with('userInfo', $this->constructString([
-                '%s%s'  => $username,
-                '%s:%s' => rawurlencode($password),
+                '%s%s' => $username,
+                '%s:%s' => rawurlencode((string) $password),
             ]));
         }
 
@@ -391,11 +391,11 @@ class Uri implements UriInterface
     public function __toString()
     {
         return $this->constructString([
-            '%s%s:'  => $this->getScheme(),
+            '%s%s:' => $this->getScheme(),
             '%s//%s' => $this->getAuthority(),
-            '%s%s'   => $this->getNormalizedUriPath(),
-            '%s?%s'  => $this->getQuery(),
-            '%s#%s'  => $this->getFragment(),
+            '%s%s' => $this->getNormalizedUriPath(),
+            '%s?%s' => $this->getQuery(),
+            '%s#%s' => $this->getFragment(),
         ]);
     }
 
@@ -409,7 +409,7 @@ class Uri implements UriInterface
         $formats = array_keys($components);
         $values = array_values($components);
         $keys = array_keys(array_filter($values, function ($value) {
-            return null !== $value && '' !== $value;
+            return $value !== null && $value !== '';
         }));
 
         return array_reduce($keys, function ($string, $key) use ($formats, $values) {

--- a/vendor/riimu/kit-urlparser/src/UriParser.php
+++ b/vendor/riimu/kit-urlparser/src/UriParser.php
@@ -36,20 +36,27 @@ class UriParser
     /** Parsing mode that allows UTF-8 characters in some URI components */
     const MODE_UTF8 = 2;
 
-    /** Parsing mode that also converts international domain names to ascii */
+    /**
+     * Parsing mode that also converts international domain names to ascii.
+     * @deprecated Use MODE_IDNA instead
+     * @see UriParser::MODE_IDNA
+     */
     const MODE_IDNA2003 = 4;
+
+    /** Parsing mode that also converts international domain names to ascii */
+    const MODE_IDNA = 4;
 
     /** @var array<string,string> List of methods used to assign the URI components */
     private static $setters = [
-        'scheme'        => 'withScheme',
-        'host'          => 'withHost',
-        'port'          => 'withPort',
-        'path_abempty'  => 'withPath',
+        'scheme' => 'withScheme',
+        'host' => 'withHost',
+        'port' => 'withPort',
+        'path_abempty' => 'withPath',
         'path_absolute' => 'withPath',
         'path_noscheme' => 'withPath',
         'path_rootless' => 'withPath',
-        'query'         => 'withQuery',
-        'fragment'      => 'withFragment',
+        'query' => 'withQuery',
+        'fragment' => 'withFragment',
     ];
 
     /** @var int The current parsing mode */
@@ -76,9 +83,9 @@ class UriParser
      *   query and fragment components of the URI. These characters will be
      *   converted to appropriate percent encoded sequences.
      *
-     * - `MODE_IDNA2003` also allows UTF-8 characters in the domain name and
+     * - `MODE_IDNA` also allows UTF-8 characters in the domain name and
      *   converts the international domain name to ascii according to the IDNA
-     *   2003 standard.
+     *   standard.
      *
      * @param int $mode One of the parsing mode constants
      */
@@ -183,11 +190,12 @@ class UriParser
     {
         if (preg_match('/^[\\x00-\\x7F]*$/', $hostname)) {
             return $hostname;
-        } elseif ($this->mode !== self::MODE_IDNA2003) {
+        } elseif ($this->mode !== self::MODE_IDNA) {
             throw new \InvalidArgumentException("Invalid hostname '$hostname'");
         }
 
-        $hostname = idn_to_ascii($hostname);
+        $mode = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : INTL_IDNA_VARIANT_2003;
+        $hostname = idn_to_ascii($hostname, IDNA_DEFAULT, $mode);
 
         if ($hostname === false) {
             throw new \InvalidArgumentException("Invalid hostname '$hostname'");

--- a/vendor/riimu/kit-urlparser/src/UriPattern.php
+++ b/vendor/riimu/kit-urlparser/src/UriPattern.php
@@ -58,7 +58,7 @@ class UriPattern
      * @param array $matches Provides the matched sub sections from the match
      * @return bool True if the URI matches, false if not
      */
-    public function matchUri($uri, & $matches = [])
+    public function matchUri($uri, &$matches = [])
     {
         if ($this->matchAbsoluteUri($uri, $matches)) {
             return true;
@@ -73,7 +73,7 @@ class UriPattern
      * @param array $matches Provides the matched sub sections from the match
      * @return bool True if the URI matches, false if not
      */
-    public function matchAbsoluteUri($uri, & $matches = [])
+    public function matchAbsoluteUri($uri, &$matches = [])
     {
         return $this->match(self::$absoluteUri, $uri, $matches);
     }
@@ -84,7 +84,7 @@ class UriPattern
      * @param array $matches Provides the matched sub sections from the match
      * @return bool True if the URI matches, false if not
      */
-    public function matchRelativeUri($uri, & $matches = [])
+    public function matchRelativeUri($uri, &$matches = [])
     {
         return $this->match(self::$relativeUri, $uri, $matches);
     }
@@ -95,7 +95,7 @@ class UriPattern
      * @param array $matches Provides the matched sub sections from the match
      * @return bool True if the scheme matches, false if not
      */
-    public function matchScheme($scheme, & $matches = [])
+    public function matchScheme($scheme, &$matches = [])
     {
         return $this->match(self::$scheme, $scheme, $matches);
     }
@@ -106,7 +106,7 @@ class UriPattern
      * @param array $matches Provides the matched sub sections from the match
      * @return bool True if the host matches, false if not
      */
-    public function matchHost($host, & $matches = [])
+    public function matchHost($host, &$matches = [])
     {
         return $this->match(self::$host, $host, $matches);
     }
@@ -118,7 +118,7 @@ class UriPattern
      * @param array $matches The provided list of literal sub patterns
      * @return bool True if the pattern matches, false if not
      */
-    private function match($pattern, $subject, & $matches)
+    private function match($pattern, $subject, &$matches)
     {
         $matches = [];
         $subject = (string) $subject;


### PR DESCRIPTION
[Mein PR](https://github.com/Riimu/Kit-UrlParser/pull/4) beim Kit-UrlParser wurde gemerged und ein [neues Release](https://github.com/Riimu/Kit-UrlParser/releases/tag/v2.2.0) erstellt. Daher können wir wieder weg von meinem Fork gehen und die offiziellen Releases verwenden.

Ungetestet!