### PR TITLE
Vereinheitlichung Rückgabewert Seo::getTags

### DIFF
--- a/lib/Url/Seo.php
+++ b/lib/Url/Seo.php
@@ -34,7 +34,7 @@ class Seo
     public function getTags()
     {
         if (!$this->isUrl()) {
-            return [];
+            return '';
         }
         $tags = [];
         $tagsOg = [];


### PR DESCRIPTION
Seo::getTags sollte nicht entweder Array oder String zurückgeben. Nun wird ein Leerstring zurückgegeben, falls kein UrlManager existiert, d. h. die URL nicht zu einem Profil zugeordnet werden kann.