### PR TITLE
Update UrlManager.php

### DIFF
--- a/lib/Url/UrlManager.php
+++ b/lib/Url/UrlManager.php
@@ -359,6 +359,11 @@ class UrlManager
                     continue;
                 }
 
+                // Prüfen ob die clang ID mit dem Profil übereinstimmt
+                if ($clangId != $profile->getArticleClangId()) {
+                    continue;
+                }
+                
                 $urlRecord = self::getForRewriteUrl($profile, (int) $urlParamValue, $clangId);
                 if (!$urlRecord) {
                     // Urls erstellen

--- a/lib/Url/UrlManager.php
+++ b/lib/Url/UrlManager.php
@@ -360,7 +360,7 @@ class UrlManager
                 }
 
                 // Prüfen ob die clang ID mit dem Profil übereinstimmt
-                if ($clangId != $profile->getArticleClangId()) {
+                if ($clangId != $profile->getArticleClangId() && $profile->getArticleClangId() != 0) {
                     continue;
                 }
                 


### PR DESCRIPTION
Prüfen ob die übergebene clang ID mit dem Profil übereinstimmt.

Wenn das nicht geprüft wird, wird der Datensatz womöglich nicht gefunden wenn ein Datensatz in verschiedenen Sprachen/Profilen aber im gleichen Namespace verfügbar sein soll. 

Bei mir äusserte sich das Problem, wenn ich in Sprache 1 per rex_getUrl einen Link zum gleichen Datensatz in Sprache 2 ausgeben wollte.