### PR TITLE
Update Profile.php: get-Return-Type "?self"

### DIFF
--- a/lib/Url/Profile.php
+++ b/lib/Url/Profile.php
@@ -488,7 +488,7 @@ class Profile
      *
      * @param int $id Profile id
      *
-     * @return self
+     * @return ?self
      */
     public static function get($id)
     {


### PR DESCRIPTION
Bei der RexStan-Überprüfung von "neues" kam eine Meldung

**'Strict comparison using !== between null and Url\Profile will always evaluate to true.'**

für die IF-Abfrage in 
```php
        $profile = Profile::get($profileId);
        if (null !== $profile) {
```
RexStan hat den ReturnType `@return self` angenommen und damit erkannt, dass die Null-Abfrage unnüzt ist, Nun liefert `Profile::get` ggf. `null`zurück. Daher Anpassung des Return-Type an die Realität 